### PR TITLE
Documentation improvements/fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ And for packaging
 
 In Debian-based systems you can install these by issuing
 
-    sudo apt install python3 python3-pip make git
+    sudo apt install python3 python3-venv python3-pip make git
 
 ## Set up a development environment
 
@@ -26,11 +26,11 @@ First, obtain code by doing a git clone:
 
 Then, you can either follow these commands manually or just execute all targets in Makefile.
 
-First, you need to set up a virtual environment. Of course, this is not mandatory, but pretty handy.
+First, you need to set up a virtual environment. This is mandatory on all systems which wish to follow [PEP 668](https://peps.python.org/pep-0668/) which prevents system-wide installs not handled by the system's package manager.
 
 I like to place my virtual env in hidden directory called `.venv`.
 
-    python -m venv .venv
+    python3 -m venv .venv
 
 or:
 
@@ -42,7 +42,7 @@ Then activate your virtual environment:
 
 All commands from now on should be executed in this virtual environment.
 
-No, you might like to do pip install to install all dependencies. You need optional-dependency called *test* in order to run tests.
+Now, you might like to do pip install to install all dependencies. You need optional-dependency called *test* in order to run tests.
 
     pip install ".[test]"
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 You can install this program by just downloading a binary file from releases and running it on your computer.
 
-If you don't know how to do that, there's also an deb-installation package for Ubuntu and probably other Debian-like operating systems.
+If you don't know how to do that, there's also a deb-installation package for Ubuntu and probably other Debian-like operating systems.
 
 [Head to releases and download this!](https://github.com/heikkiket/gallery/releases)
 
@@ -10,11 +10,14 @@ If you aren't sure how to install and run these files, don't worry! This is an a
 
 ### Installing PyGObject
 
-**In Ubuntu (and hopefully Debian as well):**
+**On Ubuntu and Debian:**
 Install following packages: `python3-gi python3-gi-cairo gir1.2-gtk-3.0`
 
-**In Fedora:**
-Install following packages: `python3-gobject gtk3`
+**On Fedora:**
+Install following packages: `python3-gobject gtk4`
+
+**On Arch:**
+Install following packages: `python3-gobject gtk4`
 
 You can find more information and help about installing PyGObject from their official documentation: https://pygobject.readthedocs.io/en/latest/getting_started.html
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This project has three parts:
  * simple viewer program
 
 ## Useful links
-Before we hop to all that, here's some links that give you a quick jump to other parts of documentation
+Before we hop to all that, here are some links that give you a quick jump to other parts of documentation
 
  - [Installation](INSTALL.md)
- - [Why a world needs an UNIX-style image collection manager?](docs/why.md)
+ - [Why a world needs a UNIX-style image collection manager?](docs/why.md)
  - [Blog](docs/blog)
 
 ## gallery specification
@@ -22,16 +22,16 @@ Your image gallery is just a directory tree containing pictures plus a library.t
 ```
 ~/Pictures/gallery/
 ├── 2021
-│   └── 12
-│       └── 15
-│           └── image1.png
+│   └── 12
+│       └── 15
+│           └── image1.png
 ├── 2022
-│   ├── 01
-│   │   └── 15
-│   │       └── image2.png
-│   └── 03
-│       └── 02
-│           └── image3.jpg
+│   ├── 01
+│   │   └── 15
+│   │       └── image2.png
+│   └── 03
+│       └── 02
+│           └── image3.jpg
 └── library.toml
 ```
 
@@ -72,7 +72,7 @@ The idea here is that the whole library.toml is easily hackable so you (or other
 
 ![Picture of gallery command line tool](./docs/screenshots/gallery-cmd.png)
 
-There is a simple, alpha-level utility called `gallery` that can be used to manipulate this gallery. Currently it has following functions.
+There is a simple, alpha-level utility called `gallery` that can be used to manipulate this gallery. Currently, it has the following functions.
 
  * init
  * list
@@ -127,7 +127,7 @@ In order to function gallery-viewer needs python3 installed in the host system a
  Head to [INSTALL.md](INSTALL.md) to find out how!
 
 ## Check out changelog
-I have a ugly but functional [CHANGELOG.md](CHANGELOG.md) generated with [git-cliff](https://github.com/orhun/git-cliff).
+I have an ugly but functional [CHANGELOG.md](CHANGELOG.md) generated with [git-cliff](https://github.com/orhun/git-cliff).
 
 ## Want to contribute?
 I value that greatly! Head on to [CONTRIBUTING.md](./CONTRIBUTING.md) to find out how to build the project.


### PR DESCRIPTION
```diff
 In Debian-based systems you can install these by issuing
 
-    sudo apt install python3 python3-pip make git
+    sudo apt install python3 python3-venv python3-pip make git
```

I don't think that venv module is included in base python3 but I did not fact check myself.

```diff
-First, you need to set up a virtual environment. Of course, this is not mandatory, but pretty handy.
+First, you need to set up a virtual environment. This is mandatory on all systems which wish to follow [PEP 668](https://peps.python.org/pep-0668/) which prevents system-wide installs not handled by the system's package manager.
```

Most systems hopefully should have started to enforce PEP 668 by now which makes this mandatory on those systems.

```diff
 I like to place my virtual env in hidden directory called `.venv`.
 
-    python -m venv .venv
+    python3 -m venv .venv
```

python is provided by `python-is-python3` which might not be on all systems and shouldn't be a dependency.

```diff
-No, ...
+Now, ...
```

I believe that this is a brainfart typo.

```diff
-If you don't know how to do that, there's also an deb-installation package ...
+If you don't know how to do that, there's also a deb-installation package ...
```

"deb" does not start with a vowel.

```diff
 ### Installing PyGObject
 
-**In Ubuntu (and hopefully Debian as well):**
+**On Ubuntu and Debian:**
 Install following packages: `python3-gi python3-gi-cairo gir1.2-gtk-3.0`
 
-**In Fedora:**
-Install following packages: `python3-gobject gtk3`
+**On Fedora:**
+Install following packages: `python3-gobject gtk4`
+
+**On Arch:**
+Install following packages: `python3-gobject gtk4`
```

I checked that those packages do exist on Debian and PyGObject has updated its documentation to mention gtk4 instead of gtk3 on Fedora/Arch.

```diff
-Before we hop to all that, here's some links ...
+Before we hop to all that, here are some links ...
```

"some links" is not singular but plural.

```diff
  - [Installation](INSTALL.md)
- - [Why a world needs an UNIX-style image collection manager?](docs/why.md)
+ - [Why a world needs a UNIX-style image collection manager?](docs/why.md)
  - [Blog](docs/blog)
```

I believe that most English speakers pronounce UNIX with a starting consonant kinda like "YOO-nicks", like in the word "university".

```diff
 ~/Pictures/gallery/
 ├── 2021
-│   └── 12
-│       └── 15
-│           └── image1.png
+│   └── 12
+│       └── 15
+│           └── image1.png
 ├── 2022
-│   ├── 01
-│   │   └── 15
-│   │       └── image2.png
-│   └── 03
-│       └── 02
-│           └── image3.jpg
+│   ├── 01
+│   │   └── 15
+│   │       └── image2.png
+│   └── 03
+│       └── 02
+│           └── image3.jpg
 └── library.toml
 ```

Replaced whatever c2a0 chars were with regular good old spaces.

 ```diff
-... gallery. Currently it has following functions.
+... gallery. Currently, it has the following functions.
```

A spell checker said: `A comma may be missing after the conjunctive/linking adverb 'Currently'.`.

```diff
 ## Check out changelog
-I have a ugly but functional [CHANGELOG.md](CHANGELOG.md) generated with [git-cliff](https://github.com/orhun/git-cliff).
+I have an ugly but functional [CHANGELOG.md](CHANGELOG.md) generated with [git-cliff](https://github.com/orhun/git-cliff).
```

"ugly" does start with a vowel and is not pronounced like "jug-ly".